### PR TITLE
✨ Introduce `elevated=5` and refine surface elevation scale

### DIFF
--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ✨ Introduce `elevated=5` and refine surface elevation scale
 
+### Changed
+
+- MinimalSurfaceDialog: `open` now defaults to `false` (previously unspecified via `$bindable()`).
 ## [1.2.1] - 2025-08-28
 
 ### Added

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -10,16 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ✨ Introduce `elevated=5` and refine surface elevation scale
+- Elevation-to-surface mapping:
+  - 0 → `--color-surfaceContainerLowest`
+  - 1 → `--color-surface`
+  - 2 → `--color-surfaceContainerLow`
+  - 3 → `--color-surfaceContainer`
+  - 4 → `--color-surfaceContainerHigh`
+  - 5 → `--color-surfaceContainerHighest`
 
 ### Changed
 
-- MinimalSurfaceDialog: `open` now defaults to `false` (previously unspecified via `$bindable()`).
+- `MinimalSurfaceDialog`: `open` now defaults to `false` (previously unspecified via `$bindable()`).
+
 ## [1.2.1] - 2025-08-28
 
 ### Added
 
-- MinimalSurfaceDialog component
-- SurfaceContainer component
+- `MinimalSurfaceDialog` component,
+- `SurfaceContainer` component,
 
 ## [1.0.1] - 2025-08-23
 

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2025-08-29
+
+### Added
+
+- ✨ Introduce `elevated=5` and refine surface elevation scale
+
 ## [1.2.1] - 2025-08-28
 
 ### Added

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-08-28
+
+### Added
+
+- MinimalSurfaceDialog component
+- SurfaceContainer component
+
 ## [1.0.1] - 2025-08-23
 
 ### Changed

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `MinimalSurfaceDialog`: `open` now defaults to `false` (previously unspecified via `$bindable()`).
+- `SurfaceContainer`: default `elevated` is now `1` (previously `0`).
+- `MinimalSurfaceDialog`: default `elevated` is `1`.
 
 ## [1.2.1] - 2025-08-28
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@celar-ui/svelte",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"license": "MIT",
 	"author": {
 		"name": "cuikho210",

--- a/packages/svelte/src/lib/containment/SurfaceContainer.svelte
+++ b/packages/svelte/src/lib/containment/SurfaceContainer.svelte
@@ -6,7 +6,7 @@
 		elevated?: 0 | 1 | 2 | 3 | 4 | 5;
 	}
 
-	let { elevated = 0, ...rest }: SurfaceContainerProps = $props();
+	let { elevated = 1, ...rest }: SurfaceContainerProps = $props();
 </script>
 
 <Container {...rest} data-surface-container data-elevated={elevated} />

--- a/packages/svelte/src/lib/containment/SurfaceContainer.svelte
+++ b/packages/svelte/src/lib/containment/SurfaceContainer.svelte
@@ -3,7 +3,7 @@
 	import Container, { type ContainerProps } from './Container.svelte';
 
 	export interface SurfaceContainerProps extends ContainerProps {
-		elevated?: 0 | 1 | 2 | 3 | 4;
+		elevated?: 0 | 1 | 2 | 3 | 4 | 5;
 	}
 
 	let { elevated = 0, ...rest }: SurfaceContainerProps = $props();

--- a/packages/svelte/src/lib/containment/styles/surface-container.scss
+++ b/packages/svelte/src/lib/containment/styles/surface-container.scss
@@ -6,16 +6,22 @@
 	// Default: Elevated 0
 	background-color: var(--color-background);
 
+	&[data-elevated='0'] {
+		--color-background: var(--color-surfaceContainerLowest);
+	}
 	&[data-elevated='1'] {
-		--color-background: var(--color-surfaceContainerLow);
+		--color-background: var(--color-surface);
 	}
 	&[data-elevated='2'] {
-		--color-background: var(--color-surfaceContainer);
+		--color-background: var(--color-surfaceContainerLow);
 	}
 	&[data-elevated='3'] {
-		--color-background: var(--color-surfaceContainerHigh);
+		--color-background: var(--color-surfaceContainer);
 	}
 	&[data-elevated='4'] {
+		--color-background: var(--color-surfaceContainerHigh);
+	}
+	&[data-elevated='5'] {
 		--color-background: var(--color-surfaceContainerHighest);
 	}
 }

--- a/packages/svelte/src/lib/overlay/MinimalSurfaceDialog.svelte
+++ b/packages/svelte/src/lib/overlay/MinimalSurfaceDialog.svelte
@@ -14,7 +14,7 @@
 
 	let {
 		open = $bindable(false),
-		elevated,
+		elevated = 1,
 		children,
 		header,
 		footer,

--- a/packages/svelte/src/lib/overlay/MinimalSurfaceDialog.svelte
+++ b/packages/svelte/src/lib/overlay/MinimalSurfaceDialog.svelte
@@ -9,11 +9,11 @@
 	type MinimalSurfaceDialogProps = MinimalDialogProps & {
 		header?: Snippet;
 		footer?: Snippet;
-		elevated?: 0 | 1 | 2 | 3 | 4;
+		elevated?: 0 | 1 | 2 | 3 | 4 | 5;
 	};
 
 	let {
-		open = $bindable(),
+		open = $bindable(false),
 		elevated,
 		children,
 		header,

--- a/packages/svelte/src/routes/components/SurfaceContainers.svelte
+++ b/packages/svelte/src/routes/components/SurfaceContainers.svelte
@@ -8,10 +8,9 @@
 	<Gap />
 	<Spacer direction="column">
 		<SurfaceContainer fluid>Default 0</SurfaceContainer>
-		<SurfaceContainer fluid elevated={1}>Elevated 1</SurfaceContainer>
-		<SurfaceContainer fluid elevated={2}>Elevated 2</SurfaceContainer>
-		<SurfaceContainer fluid elevated={3}>Elevated 3</SurfaceContainer>
-		<SurfaceContainer fluid elevated={4}>Elevated 4</SurfaceContainer>
-		<SurfaceContainer fluid elevated={5}>Elevated 5</SurfaceContainer>
+
+		{#each [1, 2, 3, 4, 5] as level (level)}
+			<SurfaceContainer fluid elevated={level as 0}>Elevated {level}</SurfaceContainer>
+		{/each}
 	</Spacer>
 </Card>

--- a/packages/svelte/src/routes/components/SurfaceContainers.svelte
+++ b/packages/svelte/src/routes/components/SurfaceContainers.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
+	import Spacer from '$lib/containment/Spacer.svelte';
 	import { Card, Gap, SurfaceContainer } from '$lib/index.js';
 </script>
 
 <Card>
 	<h3>SurfaceContainers</h3>
 	<Gap />
-	<SurfaceContainer>Default 0</SurfaceContainer>
-	<Gap size=".5rem" />
-	<SurfaceContainer elevated={1}>Elevated 1</SurfaceContainer>
-	<Gap size=".5rem" />
-	<SurfaceContainer elevated={2}>Elevated 2</SurfaceContainer>
-	<Gap size=".5rem" />
-	<SurfaceContainer elevated={3}>Elevated 3</SurfaceContainer>
-	<Gap size=".5rem" />
-	<SurfaceContainer elevated={4}>Elevated 4</SurfaceContainer>
+	<Spacer direction="column">
+		<SurfaceContainer fluid>Default 0</SurfaceContainer>
+		<SurfaceContainer fluid elevated={1}>Elevated 1</SurfaceContainer>
+		<SurfaceContainer fluid elevated={2}>Elevated 2</SurfaceContainer>
+		<SurfaceContainer fluid elevated={3}>Elevated 3</SurfaceContainer>
+		<SurfaceContainer fluid elevated={4}>Elevated 4</SurfaceContainer>
+		<SurfaceContainer fluid elevated={5}>Elevated 5</SurfaceContainer>
+	</Spacer>
 </Card>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added elevation level 5 and refined visual mapping across elevation levels (0–5).
  - Surface containers support a new fluid layout option; examples now show elevations 0–5.

- **Changed**
  - Surface containers and minimal surface dialogs now default to a higher elevation (affects visual surface).
  - Minimal Surface Dialog now renders closed by default.

- **Chores**
  - Bumped package version to 1.2.2 and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->