### PR TITLE
fixing AdaptiveSidebar styling

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@celar-ui/svelte",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"license": "MIT",
 	"author": {
 		"name": "cuikho210",

--- a/packages/svelte/src/lib/navigation/AdaptiveSidebar.svelte
+++ b/packages/svelte/src/lib/navigation/AdaptiveSidebar.svelte
@@ -13,7 +13,7 @@
 		open = $bindable(false),
 		collapsedSize = '80px',
 		expandedSize = '300px',
-		elevated = 2,
+		elevated = 3,
 		children,
 		...rest
 	}: AdaptiveSidebarProps = $props();
@@ -73,6 +73,7 @@
 		height: 100vh;
 		width: var(--expanded);
 		padding: var(--gap);
+		border-radius: 0;
 		border-top-right-radius: var(--gap--x2);
 		border-bottom-right-radius: var(--gap--x2);
 		max-width: 80vw;

--- a/packages/svelte/src/lib/navigation/AdaptiveSidebar.svelte
+++ b/packages/svelte/src/lib/navigation/AdaptiveSidebar.svelte
@@ -73,9 +73,7 @@
 		height: 100vh;
 		width: var(--expanded);
 		padding: var(--gap);
-		border-radius: 0;
-		border-top-right-radius: var(--gap--x2);
-		border-bottom-right-radius: var(--gap--x2);
+		border-radius: 0 var(--gap--x2) var(--gap--x2) 0;
 		max-width: 80vw;
 		overflow: hidden;
 		transition-property: transform, width, opacity, visibility;


### PR DESCRIPTION
- **package.json**: Increment version to 1.8.1.
- **src/lib/navigation/AdaptiveSidebar.svelte**:
    - Increase `elevated` prop from 2 to 3.
    - Remove `border-radius: 0` to allow sidebar to use its own border-radius.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted sidebar appearance: increased default elevation and refined corner border-radius for a smoother visual edge.

* **Chores**
  * Package version updated to 1.8.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->