### PR TITLE
chore(svelte): include binary files in published package

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -27,6 +27,7 @@
 	"files": [
 		"dist",
 		"src/styles",
+		"src/bin",
 		"!dist/**/*.test.*",
 		"!dist/**/*.spec.*"
 	],


### PR DESCRIPTION
- Add `src/bin` to the `files` array in `packages/svelte/package.json` to ensure the theme generation CLI is distributed with the package.