### PR TITLE
feat(svelte): expand breakpoint options and refine input styles

### DIFF
--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-16
+
+### Changed
+
+- **Container**: Added `lg`, `xl`, `x2xl` breakpoint props for larger container sizes
+- **Dialog components**: Added `lg`, `xl`, `x2xl` breakpoint props (CommandDialog, Dialog, MinimalDialog)
+- **Input padding**: Unified padding from `--spacing(1.5)` to `--spacing(2)` (TextInput, ColorInput, FileInput)
+- **Slider thumb**: Reduced thumb size from 8 to 6 units; simplified margin calculation
+
+### Added
+
+- **container-sizing utility**: Extracted container breakpoint styles to reusable utility in theme
+- **elevated utility**: Extracted surface elevation styles to reusable utility for SurfaceContainer
+
+### Fixed
+
+- **Container**: Migrated breakpoint styles to `@apply container-sizing` utility
+- **SurfaceContainer**: Migrated elevation styles to `@apply elevated` utility
+
+---
+
 ## [2.0.2] - 2026-04-16
 
 ### Changed

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@celar-ui/svelte",
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"license": "MIT",
 	"author": {
 		"name": "cuikho210",

--- a/packages/svelte/src/lib/containment/Container.svelte
+++ b/packages/svelte/src/lib/containment/Container.svelte
@@ -6,13 +6,26 @@
 		xs?: boolean;
 		sm?: boolean;
 		md?: boolean;
+		lg?: boolean;
+		xl?: boolean;
+		x2xl?: boolean;
 		fluid?: boolean;
 	}
 
-	let { children, xs, sm, md, fluid, ...rest }: ContainerProps = $props();
+	let { children, xs, sm, md, lg, xl, x2xl, fluid, ...rest }: ContainerProps = $props();
 </script>
 
-<section {...rest} data-container data-xs={xs} data-sm={sm} data-md={md} data-fluid={fluid}>
+<section
+	{...rest}
+	data-container
+	data-xs={xs}
+	data-sm={sm}
+	data-md={md}
+	data-lg={lg}
+	data-xl={xl}
+	data-2xl={x2xl}
+	data-fluid={fluid}
+>
 	{#if children}
 		{@render children()}
 	{/if}

--- a/packages/svelte/src/lib/containment/styles/container.css
+++ b/packages/svelte/src/lib/containment/styles/container.css
@@ -2,25 +2,10 @@
 
 @layer components {
 	[data-container] {
+		@apply container-sizing;
 		position: relative;
 		margin: 0 auto;
 		padding: --spacing(4);
 		box-sizing: border-box;
-
-		&[data-xs='true'] {
-			max-width: var(--breakpoint-xs);
-		}
-
-		&[data-sm='true'] {
-			max-width: var(--breakpoint-sm);
-		}
-
-		&[data-md='true'] {
-			max-width: var(--breakpoint-md);
-		}
-
-		&[data-fluid='true'] {
-			width: 100%;
-		}
 	}
 }

--- a/packages/svelte/src/lib/containment/styles/surface-container.css
+++ b/packages/svelte/src/lib/containment/styles/surface-container.css
@@ -2,28 +2,8 @@
 
 @layer components {
 	[data-surface-container] {
-		--color-background: var(--color-surface);
-
+		@apply elevated;
 		border-radius: var(--radius-4xl);
 		background-color: var(--color-background);
-
-		&[data-elevated='0'] {
-			--color-background: var(--color-surfaceContainerLowest);
-		}
-		&[data-elevated='1'] {
-			--color-background: var(--color-surface);
-		}
-		&[data-elevated='2'] {
-			--color-background: var(--color-surfaceContainerLow);
-		}
-		&[data-elevated='3'] {
-			--color-background: var(--color-surfaceContainer);
-		}
-		&[data-elevated='4'] {
-			--color-background: var(--color-surfaceContainerHigh);
-		}
-		&[data-elevated='5'] {
-			--color-background: var(--color-surfaceContainerHighest);
-		}
 	}
 }

--- a/packages/svelte/src/lib/containment/styles/surface-container.css
+++ b/packages/svelte/src/lib/containment/styles/surface-container.css
@@ -4,6 +4,5 @@
 	[data-surface-container] {
 		@apply elevated;
 		border-radius: var(--radius-4xl);
-		background-color: var(--color-background);
 	}
 }

--- a/packages/svelte/src/lib/inputs/ColorInput.svelte
+++ b/packages/svelte/src/lib/inputs/ColorInput.svelte
@@ -29,7 +29,7 @@
 			justify-content: flex-start;
 			align-items: center;
 			border-radius: var(--radius-2xl);
-			padding: --spacing(1.5) 0;
+			padding: --spacing(2) 0;
 			width: 100%;
 
 			> input {

--- a/packages/svelte/src/lib/inputs/FileInput.svelte
+++ b/packages/svelte/src/lib/inputs/FileInput.svelte
@@ -34,7 +34,7 @@
 			justify-content: flex-start;
 			align-items: center;
 			border-radius: var(--radius-2xl);
-			padding: --spacing(1.5) 0;
+			padding: --spacing(2) 0;
 			width: 100%;
 
 			input {

--- a/packages/svelte/src/lib/inputs/Slider.svelte
+++ b/packages/svelte/src/lib/inputs/Slider.svelte
@@ -34,7 +34,7 @@
 		@apply bg-primary h-2 rounded-2xl;
 	}
 	@utility thumb {
-		@apply bg-primary box-border h-8 w-8 rounded-[50%] border-none;
+		@apply bg-primary box-border h-6 w-6 rounded-[50%] border-none;
 	}
 
 	@layer components {
@@ -77,7 +77,7 @@
 				}
 
 				&::-webkit-slider-thumb {
-					margin-top: calc(0.5 * (--spacing(2) - --spacing(8)));
+					margin-top: calc(0.5 * --spacing(-4));
 					@apply thumb;
 				}
 				&::-moz-range-thumb {

--- a/packages/svelte/src/lib/inputs/TextInput.svelte
+++ b/packages/svelte/src/lib/inputs/TextInput.svelte
@@ -35,7 +35,7 @@
 				@apply border-onBackground/20 rounded-2xl border border-solid transition-all;
 				box-sizing: border-box;
 				background-color: transparent;
-				padding: --spacing(1.5) --spacing(4);
+				padding: --spacing(2) --spacing(4);
 				padding-left: --spacing(14);
 				width: 100%;
 				font-size: inherit;

--- a/packages/svelte/src/lib/overlay/CommandDialog.svelte
+++ b/packages/svelte/src/lib/overlay/CommandDialog.svelte
@@ -9,6 +9,9 @@
 		xs?: boolean;
 		sm?: boolean;
 		md?: boolean;
+		lg?: boolean;
+		xl?: boolean;
+		x2xl?: boolean;
 		fluid?: boolean;
 		transitionDuration?: number;
 		placeholder?: string;

--- a/packages/svelte/src/lib/overlay/CommandDialog.svelte
+++ b/packages/svelte/src/lib/overlay/CommandDialog.svelte
@@ -6,13 +6,6 @@
 
 	type CommandDialogProps = MinimalDialogProps & {
 		trigger?: Snippet<[{ props: Record<string, unknown> }]>;
-		xs?: boolean;
-		sm?: boolean;
-		md?: boolean;
-		lg?: boolean;
-		xl?: boolean;
-		x2xl?: boolean;
-		fluid?: boolean;
 		transitionDuration?: number;
 		placeholder?: string;
 		emptyText?: string;

--- a/packages/svelte/src/lib/overlay/Dialog.svelte
+++ b/packages/svelte/src/lib/overlay/Dialog.svelte
@@ -13,6 +13,9 @@
 		xs?: boolean;
 		sm?: boolean;
 		md?: boolean;
+		lg?: boolean;
+		xl?: boolean;
+		x2xl?: boolean;
 		fluid?: boolean;
 		transitionDuration?: number;
 	};
@@ -26,6 +29,9 @@
 		xs,
 		sm,
 		md,
+		lg,
+		xl,
+		x2xl,
 		fluid,
 		transitionDuration = 200,
 		...rest
@@ -52,6 +58,9 @@
 			data-xs={xs}
 			data-sm={sm}
 			data-md={md}
+			data-lg={lg}
+			data-xl={xl}
+			data-2xl={x2xl}
 			data-fluid={fluid}
 			data-celar-dialog-content
 		>

--- a/packages/svelte/src/lib/overlay/MinimalDialog.svelte
+++ b/packages/svelte/src/lib/overlay/MinimalDialog.svelte
@@ -10,6 +10,9 @@
 		xs?: boolean;
 		sm?: boolean;
 		md?: boolean;
+		lg?: boolean;
+		xl?: boolean;
+		x2xl?: boolean;
 		fluid?: boolean;
 		transitionDuration?: number;
 	};
@@ -21,6 +24,9 @@
 		xs,
 		sm,
 		md,
+		lg,
+		xl,
+		x2xl,
 		fluid,
 		transitionDuration = 200,
 		...rest
@@ -47,6 +53,9 @@
 			data-xs={xs}
 			data-sm={sm}
 			data-md={md}
+			data-lg={lg}
+			data-xl={xl}
+			data-2xl={x2xl}
 			data-fluid={fluid}
 			data-celar-dialog-content
 		>

--- a/packages/svelte/src/lib/overlay/styles/dialog.css
+++ b/packages/svelte/src/lib/overlay/styles/dialog.css
@@ -35,6 +35,15 @@
 		&[data-md='true'] {
 			max-width: min(calc(100% - --spacing(8)), var(--breakpoint-md));
 		}
+		&[data-lg='true'] {
+			max-width: min(calc(100% - --spacing(8)), var(--breakpoint-lg));
+		}
+		&[data-xl='true'] {
+			max-width: min(calc(100% - --spacing(8)), var(--breakpoint-xl));
+		}
+		&[data-2xl='true'] {
+			max-width: min(calc(100% - --spacing(8)), var(--breakpoint-2xl));
+		}
 		&[data-fluid='true'] {
 			width: 100%;
 		}

--- a/packages/svelte/src/routes/(custom-navbar)/+page.svelte
+++ b/packages/svelte/src/routes/(custom-navbar)/+page.svelte
@@ -23,7 +23,7 @@
 	{/snippet}
 </AppBar>
 
-<Container sm>
+<Container lg>
 	<OutlinedButton href="/adaptive-sidebar">Adaptive Sidebar</OutlinedButton>
 	<Gap />
 	<ColorPalette />

--- a/packages/svelte/src/routes/(custom-navbar)/components/+page.svelte
+++ b/packages/svelte/src/routes/(custom-navbar)/components/+page.svelte
@@ -35,7 +35,7 @@
 	{/snippet}
 </AppBar>
 
-<Container sm>
+<Container md>
 	<Breadcrumb>
 		<a href="/">Home</a>
 		<a href="/components">Components</a>

--- a/packages/svelte/src/styles/index.css
+++ b/packages/svelte/src/styles/index.css
@@ -4,3 +4,52 @@
 @theme {
 	--breakpoint-xs: 30rem;
 }
+
+@utility container-sizing {
+	&[data-xs='true'] {
+		max-width: var(--breakpoint-xs);
+	}
+	&[data-sm='true'] {
+		max-width: var(--breakpoint-sm);
+	}
+	&[data-md='true'] {
+		max-width: var(--breakpoint-md);
+	}
+	&[data-lg='true'] {
+		max-width: var(--breakpoint-lg);
+	}
+	&[data-xl='true'] {
+		max-width: var(--breakpoint-xl);
+	}
+	&[data-2xl='true'] {
+		max-width: var(--breakpoint-2xl);
+	}
+	&[data-fluid='true'] {
+		width: 100%;
+	}
+}
+
+@utility elevated {
+	--color-background: var(--color-surface);
+
+	&[data-elevated='0'] {
+		--color-background: var(--color-surfaceContainerLowest);
+	}
+	&[data-elevated='1'] {
+		--color-background: var(--color-surface);
+	}
+	&[data-elevated='2'] {
+		--color-background: var(--color-surfaceContainerLow);
+	}
+	&[data-elevated='3'] {
+		--color-background: var(--color-surfaceContainer);
+	}
+	&[data-elevated='4'] {
+		--color-background: var(--color-surfaceContainerHigh);
+	}
+	&[data-elevated='5'] {
+		--color-background: var(--color-surfaceContainerHighest);
+	}
+
+	background-color: var(--color-background);
+}


### PR DESCRIPTION
- Added `lg`, `xl`, and `x2xl` props to `Container.svelte`, `Dialog.svelte`, `MinimalDialog.svelte`, and `CommandDialog.svelte` to support larger layout widths
- Extracted repeated sizing and elevation logic into `@utility container-sizing` and `@utility elevated` in `index.css` to improve maintainability in `container.css` and `surface-container.css`
- Increased padding to `--spacing(2)` in `TextInput.svelte`, `ColorInput.svelte`, and `FileInput.svelte` for better visual consistency
- Reduced thumb size and simplified margin calculations in `Slider.svelte` for a more refined appearance
- Bumped version to `2.1.0` in `package.json` and updated `CHANGELOG.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v2.1.0

* **New Features**
  * Container and dialog components now support larger responsive breakpoints for improved layout flexibility.
  * Input component padding standardized for consistent visual spacing.

* **Updates**
  * Slider thumb size refined for better visual balance.

* **Chores**
  * Refactored theme utilities for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->