### PR TITLE
refactor: migrate CSS layers from components to base

### DIFF
--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-04-17
+
+### Changed
+
+- **PostCSS layers**: Migrated all component styles from `@layer components` to `@layer base` for Tailwind 4 compatibility
+- **@reference directives**: Added `@reference 'tailwindcss'` to all component stylesheets
+
+### Fixed
+
+- **Demo styles**: Moved `@import 'tailwindcss'` from styles/index.css to demo's style.css
+
+---
+
 ## [2.1.0] - 2026-04-16
 
 ### Changed

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Demo styles**: Moved `@import 'tailwindcss'` from styles/index.css to demo's style.css
 
+### ⚠️ Breaking Changes
+
+- **Cascade precedence**: Components now have lower cascade precedence due to migration from `@layer components` to `@layer base`
+
 ---
 
 ## [2.1.0] - 2026-04-16

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,6 +1,6 @@
 # Celar UI for Svelte
 
-A Material Design 3 component library for Svelte, powered by Bits-ui and Tailwind CSS 4.
+A component library for Svelte, powered by Bits-ui and Tailwind CSS 4.
 
 ## Quick Start
 
@@ -43,7 +43,7 @@ Then update your root CSS:
 ```css
 @import '@celar-ui/svelte/styles/index.css';
 @import 'path/to/theme.css';
-@source '../../../node_modules/@celar-ui/svelte/dist';
+@source 'path/to/node_modules/@celar-ui/svelte/dist';
 ```
 
 ## Available Components

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,58 +1,60 @@
-# Svelte library
+# Celar UI for Svelte
 
-Everything you need to build a Svelte library, powered by [`sv`](https://npmjs.com/package/sv).
+A Material Design 3 component library for Svelte, powered by Bits-ui and Tailwind CSS 4.
 
-Read more about creating a library [in the docs](https://svelte.dev/docs/kit/packaging).
+## Quick Start
 
-## Creating a project
-
-If you're seeing this, you've probably already done this step. Congrats!
+### 1. Install
 
 ```bash
-# create a new project in the current directory
-npx sv create
-
-# create a new project in my-app
-npx sv create my-app
+bun add @celar-ui/svelte
 ```
 
-## Developing
+### 2. Configure CSS
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+In your root CSS file:
+
+```css
+@import '@celar-ui/svelte/styles/index.css';
+@source 'path/to/node_modules/@celar-ui/svelte/dist';
+```
+
+### 3. Use Components
+
+```svelte
+<script>
+	import { FilledButton, TextInput } from '@celar-ui/svelte';
+</script>
+
+<FilledButton>Click me</FilledButton>
+<TextInput placeholder="Enter text" />
+```
+
+## Custom Theme
+
+Generate a custom theme with your brand color:
 
 ```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+npx @celar-ui/svelte -c #aabbcc -o ./theme.css
 ```
 
-Everything inside `src/lib` is part of your library, everything inside `src/routes` can be used as a showcase or preview app.
+Then update your root CSS:
 
-## Building
-
-To build your library:
-
-```bash
-npm run package
+```css
+@import '@celar-ui/svelte/styles/index.css';
+@import 'path/to/theme.css';
+@source '../../../node_modules/@celar-ui/svelte/dist';
 ```
 
-To create a production version of your showcase app:
+## Available Components
 
-```bash
-npm run build
-```
+- **Buttons**: FilledButton, ElevatedButton, OutlinedButton, TextButton, IconButton, ExpandedTextButton
+- **Inputs**: TextInput, Checkbox, RadioGroup, Switch, Slider, ColorInput, FileInput, TagInput
+- **Containment**: Container, Card, Avatar, Breadcrumb, Spacer, Gap, SurfaceContainer
+- **Navigation**: AppBar, NavigationBar, NavigationBarButton, AdaptiveSidebar, NavigationDrawer
+- **Overlay**: Dialog, CommandDialog, MinimalDialog, MinimalSurfaceDialog, Popover
+- **Misc**: Badge, DotSpinner, DuckSpinner, LinearProgressIndicator
 
-You can preview the production build with `npm run preview`.
+## License
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
-
-## Publishing
-
-Go into the `package.json` and give your package the desired name through the `"name"` option. Also consider adding a `"license"` field and point it to a `LICENSE` file which you can create from a template (one popular option is the [MIT license](https://opensource.org/license/mit/)).
-
-To publish your library to [npm](https://www.npmjs.com):
-
-```bash
-npm publish
-```
+MIT

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@celar-ui/svelte",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"license": "MIT",
 	"author": {
 		"name": "cuikho210",

--- a/packages/svelte/src/lib/buttons/styles/button_utils.css
+++ b/packages/svelte/src/lib/buttons/styles/button_utils.css
@@ -1,3 +1,4 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
 @utility button-base {

--- a/packages/svelte/src/lib/buttons/styles/elevated_button.css
+++ b/packages/svelte/src/lib/buttons/styles/elevated_button.css
@@ -1,6 +1,6 @@
 @reference './button_utils.css';
 
-@layer components {
+@layer base {
 	[data-button-elevated] {
 		@apply button-text-base bg-primaryContainer text-onPrimaryContainer shadow;
 

--- a/packages/svelte/src/lib/buttons/styles/expanded_text_button.css
+++ b/packages/svelte/src/lib/buttons/styles/expanded_text_button.css
@@ -1,6 +1,6 @@
 @reference './button_utils.css';
 
-@layer components {
+@layer base {
 	[data-button-text-expanded] {
 		@apply button-text-base;
 		background-color: transparent;

--- a/packages/svelte/src/lib/buttons/styles/filled_button.css
+++ b/packages/svelte/src/lib/buttons/styles/filled_button.css
@@ -1,6 +1,6 @@
 @reference './button_utils.css';
 
-@layer components {
+@layer base {
 	[data-button-filled] {
 		@apply button-text-base;
 		background-color: var(--color-primary);

--- a/packages/svelte/src/lib/buttons/styles/icon_button.css
+++ b/packages/svelte/src/lib/buttons/styles/icon_button.css
@@ -1,6 +1,6 @@
 @reference './button_utils.css';
 
-@layer components {
+@layer base {
 	[data-button-icon] {
 		@apply button-base;
 		flex-grow: 0;

--- a/packages/svelte/src/lib/buttons/styles/outlined_button.css
+++ b/packages/svelte/src/lib/buttons/styles/outlined_button.css
@@ -1,6 +1,6 @@
 @reference './button_utils.css';
 
-@layer components {
+@layer base {
 	[data-button-outlined] {
 		@apply button-text-base border-onBackground/20 border border-solid;
 		background-color: transparent;

--- a/packages/svelte/src/lib/buttons/styles/text_button.css
+++ b/packages/svelte/src/lib/buttons/styles/text_button.css
@@ -1,6 +1,6 @@
 @reference './button_utils.css';
 
-@layer components {
+@layer base {
 	[data-button-text] {
 		@apply button-text-base;
 		transition-property: background-color, opacity, filter;

--- a/packages/svelte/src/lib/containment/Spacer.svelte
+++ b/packages/svelte/src/lib/containment/Spacer.svelte
@@ -28,9 +28,10 @@
 </div>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-spacer] {
 			padding: 0;
 			margin: 0;

--- a/packages/svelte/src/lib/containment/styles/avatar.css
+++ b/packages/svelte/src/lib/containment/styles/avatar.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-avatar-root] {
 		display: block;
 		position: relative;

--- a/packages/svelte/src/lib/containment/styles/breadcrumb.css
+++ b/packages/svelte/src/lib/containment/styles/breadcrumb.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-breadcrumb] {
 		position: relative;
 		padding: 0;

--- a/packages/svelte/src/lib/containment/styles/card.css
+++ b/packages/svelte/src/lib/containment/styles/card.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-card] {
 		@apply shadow-lg;
 	}

--- a/packages/svelte/src/lib/containment/styles/container.css
+++ b/packages/svelte/src/lib/containment/styles/container.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-container] {
 		@apply container-sizing;
 		position: relative;

--- a/packages/svelte/src/lib/containment/styles/surface-container.css
+++ b/packages/svelte/src/lib/containment/styles/surface-container.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-surface-container] {
 		@apply elevated;
 		border-radius: var(--radius-4xl);

--- a/packages/svelte/src/lib/inputs/Checkbox.svelte
+++ b/packages/svelte/src/lib/inputs/Checkbox.svelte
@@ -55,9 +55,10 @@
 </label>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-checkbox] {
 			position: relative;
 			box-sizing: border-box;

--- a/packages/svelte/src/lib/inputs/ColorInput.svelte
+++ b/packages/svelte/src/lib/inputs/ColorInput.svelte
@@ -19,9 +19,10 @@
 </label>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-color-input] {
 			@apply border-onBackground/20 border border-solid;
 			display: flex;

--- a/packages/svelte/src/lib/inputs/FileInput.svelte
+++ b/packages/svelte/src/lib/inputs/FileInput.svelte
@@ -24,9 +24,10 @@
 </label>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-file-input] {
 			@apply border-onBackground/20 border border-solid;
 			display: flex;

--- a/packages/svelte/src/lib/inputs/RadioItem.svelte
+++ b/packages/svelte/src/lib/inputs/RadioItem.svelte
@@ -16,9 +16,10 @@
 </label>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-radio-item] {
 			@apply transition-all;
 			box-sizing: border-box;

--- a/packages/svelte/src/lib/inputs/Slider.svelte
+++ b/packages/svelte/src/lib/inputs/Slider.svelte
@@ -19,6 +19,7 @@
 </div>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
 	@utility track {
@@ -37,7 +38,7 @@
 		@apply bg-primary box-border h-6 w-6 rounded-[50%] border-none;
 	}
 
-	@layer components {
+	@layer base {
 		[data-slider] {
 			position: relative;
 			padding: 0 --spacing(4);

--- a/packages/svelte/src/lib/inputs/Switch.svelte
+++ b/packages/svelte/src/lib/inputs/Switch.svelte
@@ -18,9 +18,10 @@
 </label>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-switch] {
 			@apply rounded-lg py-1.5 pr-4 transition-all;
 			position: relative;

--- a/packages/svelte/src/lib/inputs/TagInput.svelte
+++ b/packages/svelte/src/lib/inputs/TagInput.svelte
@@ -106,9 +106,10 @@
 </div>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-tag-input] {
 			--color-background: transparent;
 

--- a/packages/svelte/src/lib/inputs/TextInput.svelte
+++ b/packages/svelte/src/lib/inputs/TextInput.svelte
@@ -20,9 +20,10 @@
 </label>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-text-input] {
 			margin: 0;
 			padding: 0;

--- a/packages/svelte/src/lib/inputs/styles/radio_group.css
+++ b/packages/svelte/src/lib/inputs/styles/radio_group.css
@@ -1,5 +1,6 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
-@layer components {
+@layer base {
 	[data-radio-group-root] {
 		position: relative;
 	}

--- a/packages/svelte/src/lib/misc/Badge.svelte
+++ b/packages/svelte/src/lib/misc/Badge.svelte
@@ -14,9 +14,10 @@
 </span>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-badge] {
 			box-sizing: border-box;
 			border-radius: var(--radius-2xl);

--- a/packages/svelte/src/lib/misc/DotSpinner.svelte
+++ b/packages/svelte/src/lib/misc/DotSpinner.svelte
@@ -70,7 +70,7 @@
 </svg>
 
 <style lang="postcss">
-	@layer components {
+	@layer base {
 		svg {
 			display: inline-block;
 			aspect-ratio: 1;

--- a/packages/svelte/src/lib/misc/DuckSpinner.svelte
+++ b/packages/svelte/src/lib/misc/DuckSpinner.svelte
@@ -138,9 +138,10 @@
 </svg>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-duck-spinner] {
 			.line {
 				fill: none;

--- a/packages/svelte/src/lib/misc/Gap.svelte
+++ b/packages/svelte/src/lib/misc/Gap.svelte
@@ -9,9 +9,10 @@
 <div data-gap style:width={size}></div>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-gap] {
 			display: block;
 			aspect-ratio: 1;

--- a/packages/svelte/src/lib/misc/LinearProgressIndicator.svelte
+++ b/packages/svelte/src/lib/misc/LinearProgressIndicator.svelte
@@ -8,9 +8,10 @@
 </div>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-linear-progress-indicator] {
 			--line-height: --spacing(1.5);
 			--anim-duration: 1.7s;

--- a/packages/svelte/src/lib/navigation/AdaptiveSidebar.svelte
+++ b/packages/svelte/src/lib/navigation/AdaptiveSidebar.svelte
@@ -47,9 +47,10 @@
 </div>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-adaptive-sidebar-backdrop] {
 			@apply bg-onBackground/20 backdrop-blur transition-all;
 			position: fixed;

--- a/packages/svelte/src/lib/navigation/AppBar.svelte
+++ b/packages/svelte/src/lib/navigation/AppBar.svelte
@@ -28,9 +28,10 @@
 </section>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-app-bar] {
 			@apply bg-background/88 backdrop-blur;
 			box-sizing: border-box;

--- a/packages/svelte/src/lib/navigation/NavigationBar.svelte
+++ b/packages/svelte/src/lib/navigation/NavigationBar.svelte
@@ -9,9 +9,10 @@
 </section>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-navigation-bar] {
 			box-sizing: border-box;
 			display: flex;

--- a/packages/svelte/src/lib/navigation/NavigationBarButton.svelte
+++ b/packages/svelte/src/lib/navigation/NavigationBarButton.svelte
@@ -24,9 +24,10 @@
 </a>
 
 <style lang="postcss">
+	@reference 'tailwindcss';
 	@reference '@celar-ui/svelte/styles/index.css';
 
-	@layer components {
+	@layer base {
 		[data-navigation-bar-button] {
 			box-sizing: border-box;
 			display: flex;

--- a/packages/svelte/src/lib/navigation/styles/navigation_drawer.css
+++ b/packages/svelte/src/lib/navigation/styles/navigation_drawer.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-navigation-drawer-backdrop] {
 		@apply bg-onBackground/20 backdrop-blur;
 		position: fixed;

--- a/packages/svelte/src/lib/overlay/styles/command.css
+++ b/packages/svelte/src/lib/overlay/styles/command.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-command-dialog] {
 		top: 25dvh;
 		left: calc(50lvw - --spacing(4));

--- a/packages/svelte/src/lib/overlay/styles/dialog.css
+++ b/packages/svelte/src/lib/overlay/styles/dialog.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-celar-dialog-overlay] {
 		@apply bg-onBackground/10 backdrop-blur;
 		position: fixed;

--- a/packages/svelte/src/lib/overlay/styles/popover.css
+++ b/packages/svelte/src/lib/overlay/styles/popover.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-popover-content] {
 		z-index: var(--z-index, 120);
 		max-width: 100vw;

--- a/packages/svelte/src/lib/overlay/styles/surface-dialog.css
+++ b/packages/svelte/src/lib/overlay/styles/surface-dialog.css
@@ -1,6 +1,7 @@
+@reference 'tailwindcss';
 @reference '@celar-ui/svelte/styles/index.css';
 
-@layer components {
+@layer base {
 	[data-minimal-surface-dialog] {
 		border-radius: var(--radius-4xl);
 

--- a/packages/svelte/src/routes/+layout.svelte
+++ b/packages/svelte/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import '$style/index.css';
 	import './style.css';
 
 	let { children } = $props();

--- a/packages/svelte/src/routes/style.css
+++ b/packages/svelte/src/routes/style.css
@@ -1,3 +1,6 @@
+@import 'tailwindcss';
+@import '$style/index.css';
+
 html,
 body {
 	margin: 0;

--- a/packages/svelte/src/styles/index.css
+++ b/packages/svelte/src/styles/index.css
@@ -1,4 +1,3 @@
-@import 'tailwindcss';
 @import './theme.css';
 
 @theme {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated library documentation with Material Design 3 component usage examples and custom theme configuration guide.

* **Style**
  * Optimized component styling architecture and Tailwind CSS integration for improved cascade layering.

* **Chores**
  * Released version 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->